### PR TITLE
Expose a method for allowing detail height change

### DIFF
--- a/akyral-details.html
+++ b/akyral-details.html
@@ -147,6 +147,21 @@ Example:
         toggle: function() {
           this.open = !this.open;
         },
+        
+         /**
+         * The `update` method adjusts the height of the details.
+         *
+         * @method update
+         */
+        update: function() {
+          var height = 0;
+
+          if (this.open) {
+            height = this.$.content.getBoundingClientRect().height + 'px';
+          }
+
+          this.$.container.style.height = height;  
+        },
 
         /**
          * The `openChanged` method is triggered when the open attribute has
@@ -155,13 +170,7 @@ Example:
          * @method openChanged
          */
         openChanged: function() {
-          var height = 0;
-
-          if (this.open) {
-            height = this.$.content.getBoundingClientRect().height + 'px';
-          }
-
-          this.$.container.style.height = height;
+          this.update();
         }
       });
     }());


### PR DESCRIPTION
Moves code from the openChanged callback that adjusts the container height to it's own method which is called by the openChanged callback.
